### PR TITLE
Revert "config: Use tether automatic upstream selection"

### DIFF
--- a/overlay/common/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/common/frameworks/base/core/res/res/values/config.xml
@@ -89,9 +89,4 @@
 
     <!-- Whether or not we should show the option to show battery percentage -->
     <bool name="config_battery_percentage_setting_available">false</bool>
-
-    <!-- When true, the tethering upstream network follows the current default
-         Internet network (except when the current default network is mobile,
-         in which case a DUN network will be used if required). -->
-    <bool name="config_tether_upstream_automatic">true</bool>
 </resources>


### PR DESCRIPTION
This is now the default in Q as per:
https://github.com/LineageOS/android_frameworks_base/commit/a78701812fed

This reverts commit 4ec881366c8f14ca423bb0b3eb8aa750f1b79e0a.

Change-Id: Ic8276126570ed0f03c8f556d7551d8f7ce6ed7a8