### PR TITLE
common: Add nano to PRODUCT_PACKAGES

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -177,6 +177,7 @@ PRODUCT_PACKAGES += \
     htop \
     lib7z \
     libsepol \
+    nano \
     pigz \
     powertop \
     setcap \


### PR DESCRIPTION
* Since `LOCAL_MODULE_TAGS := debug` is no more
  we need to add it to build manually.

Change-Id: I82378f13be30aa71766561bd0e8f04183363a52d